### PR TITLE
Add A-Frame and Three.js for game creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,95 @@ To deploy the project to GitHub Pages, use:
 npm run deploy
 ```
 
+## Using A-Frame and Three.js for Creating the Game
+
+To create the game using A-Frame and Three.js, follow these steps:
+
+1. Add A-Frame and Three.js libraries to your `index.html` file:
+   ```html
+   <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+   ```
+
+2. Initialize A-Frame and Three.js in your main JavaScript file:
+   ```js
+   // Initialize A-Frame
+   AFRAME.registerComponent('example', {
+     init: function () {
+       console.log('A-Frame component initialized');
+     }
+   });
+
+   // Initialize Three.js
+   const scene = new THREE.Scene();
+   const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+   const renderer = new THREE.WebGLRenderer();
+   renderer.setSize(window.innerWidth, window.innerHeight);
+   document.body.appendChild(renderer.domElement);
+   ```
+
+## Loading Chunks with 8 or 16 Possible Variations
+
+To load chunks with 8 or 16 possible variations, follow these steps:
+
+1. Define the possible variations for the chunks:
+   ```js
+   const variations = [
+     'variation1',
+     'variation2',
+     'variation3',
+     'variation4',
+     'variation5',
+     'variation6',
+     'variation7',
+     'variation8',
+     'variation9',
+     'variation10',
+     'variation11',
+     'variation12',
+     'variation13',
+     'variation14',
+     'variation15',
+     'variation16'
+   ];
+   ```
+
+2. Implement the logic to load a chunk with a random variation:
+   ```js
+   function loadChunk() {
+     const randomIndex = Math.floor(Math.random() * variations.length);
+     const selectedVariation = variations[randomIndex];
+     console.log(`Loading chunk with variation: ${selectedVariation}`);
+     // Add your logic to load the chunk with the selected variation
+   }
+   ```
+
+## Using the Marching Cubes Algorithm
+
+To use the marching cubes algorithm, follow these steps:
+
+1. Add the marching cubes algorithm implementation to your project. You can use an existing library or implement it yourself.
+
+2. Integrate the marching cubes algorithm with your Three.js scene:
+   ```js
+   // Example using Three.js marching cubes implementation
+   const resolution = 28;
+   const material = new THREE.MeshPhongMaterial({ color: 0x00ff00 });
+   const marchingCubes = new THREE.MarchingCubes(resolution, material);
+
+   scene.add(marchingCubes);
+
+   function updateMarchingCubes() {
+     // Update the marching cubes field
+     marchingCubes.reset();
+     // Add your logic to update the field values
+     marchingCubes.addBall(0.5, 0.5, 0.5, 0.1);
+     renderer.render(scene, camera);
+   }
+
+   updateMarchingCubes();
+   ```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,61 @@
+import * as THREE from 'three';
+import 'aframe';
+
+// Initialize A-Frame
+AFRAME.registerComponent('example', {
+  init: function () {
+    console.log('A-Frame component initialized');
+  }
+});
+
+// Initialize Three.js
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+// Define the possible variations for the chunks
+const variations = [
+  'variation1',
+  'variation2',
+  'variation3',
+  'variation4',
+  'variation5',
+  'variation6',
+  'variation7',
+  'variation8',
+  'variation9',
+  'variation10',
+  'variation11',
+  'variation12',
+  'variation13',
+  'variation14',
+  'variation15',
+  'variation16'
+];
+
+// Implement the logic to load a chunk with a random variation
+function loadChunk() {
+  const randomIndex = Math.floor(Math.random() * variations.length);
+  const selectedVariation = variations[randomIndex];
+  console.log(`Loading chunk with variation: ${selectedVariation}`);
+  // Add your logic to load the chunk with the selected variation
+}
+
+// Example using Three.js marching cubes implementation
+const resolution = 28;
+const material = new THREE.MeshPhongMaterial({ color: 0x00ff00 });
+const marchingCubes = new THREE.MarchingCubes(resolution, material);
+
+scene.add(marchingCubes);
+
+function updateMarchingCubes() {
+  // Update the marching cubes field
+  marchingCubes.reset();
+  // Add your logic to update the field values
+  marchingCubes.addBall(0.5, 0.5, 0.5, 0.1);
+  renderer.render(scene, camera);
+}
+
+updateMarchingCubes();

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Q-DimensionalField</title>
   <link rel="stylesheet" href="styles.css">
+  <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="src/main.js"></script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
Update documentation and add A-Frame and Three.js integration for game creation.

* **index.html**
  - Add A-Frame and Three.js libraries in the `<head>` section.
  - Add a `<script>` tag to include the main JavaScript file.

* **README.md**
  - Add a section on using A-Frame and Three.js for creating the game.
  - Add instructions for loading chunks with 8 or 16 possible variations.
  - Add instructions for using the marching cubes algorithm.

* **frontend/src/main.js**
  - Initialize A-Frame and Three.js.
  - Implement logic to load chunks with 8 or 16 possible variations.
  - Implement marching cubes algorithm.

