### PR TITLE
Fix color codes in chunk-component.js

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "No command needed."
+  }
+}

--- a/js/components/chunk-component.js
+++ b/js/components/chunk-component.js
@@ -72,6 +72,20 @@ AFRAME.registerComponent('chunk', {
         const hue = (height / this.data.size) * 120; // 0-120 degrees (red to green)
         const saturation = value * 100;
         const lightness = 50 + value * 20;
-        return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+        const hslColor = `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+        
+        // Convert HSL to hex
+        const hslToHex = (h, s, l) => {
+            l /= 100;
+            const a = s * Math.min(l, 1 - l) / 100;
+            const f = n => {
+                const k = (n + h / 30) % 12;
+                const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+                return Math.round(255 * color).toString(16).padStart(2, '0'); // convert to Hex and prefix "0" if needed
+            };
+            return `#${f(0)}${f(8)}${f(4)}`;
+        };
+
+        return hslToHex(hue, saturation, lightness);
     }
 });


### PR DESCRIPTION
Update `getHeightBasedColor` function in `js/components/chunk-component.js` to generate valid hex color codes.

* Convert HSL color to hex color in `getHeightBasedColor` function.
* Add `hslToHex` function to handle the conversion.
* Return the hex color code instead of HSL color code.

