### PR TITLE
Fix chunk spawning with plane and random color

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ The VR Exploration Game is an open-world experience built using A-Frame, Taichi.
 #### Hierarchy Overview
 ```
 World
-├── Chunks (64x64x64)
-│   ├── Blocks (16x16x16 per chunk)
-│   │   └── Voxels (8x8x8 per block)
+├── Parsec or Large Chunk (10x10x10)
+│   ├── Chunks (10x10x10)
+│   │   └── Blocks (10x10x10)
+│   │       └── Voxels
 │   └── Position Management
 ├── Block Management
 │   ├── Textures
@@ -197,3 +198,48 @@ To enable logging, set the `loggingEnabled` flag to `true`. To disable logging, 
 
 ### Purpose of Logging
 The purpose of logging is to provide developers with detailed insights into the game's flow and operations. This helps in debugging and understanding the game's behavior, making it easier to identify and fix issues.
+
+## Inventory Ideas
+
+### Overview
+The inventory system will allow players to collect, store, and manage various items within the game. This includes resources, tools, and other objects that can be used for crafting, building, and exploration.
+
+### Features
+- **Item Collection:**
+  - Players can collect items by interacting with the environment.
+  - Items can be picked up, dropped, and transferred between inventory slots.
+- **Inventory Slots:**
+  - The inventory will have a limited number of slots for storing items.
+  - Each slot can hold a specific type and quantity of item.
+- **Crafting System:**
+  - Players can combine items to create new tools, structures, and resources.
+  - Crafting recipes will be available for players to discover and use.
+- **Resource Management:**
+  - Players must manage their resources effectively to survive and progress in the game.
+  - Resources can be gathered from the environment and used for crafting and building.
+
+### Implementation Details
+- **UI Design:**
+  - The inventory UI will be accessible through a menu or hotkey.
+  - Items will be displayed in a grid layout with icons and descriptions.
+- **Item Types:**
+  - Common items: wood, stone, metal, food, etc.
+  - Tools: pickaxe, axe, shovel, etc.
+  - Special items: rare resources, unique tools, etc.
+- **Interaction:**
+  - Players can interact with the inventory using VR controllers or keyboard/mouse.
+  - Drag-and-drop functionality for moving items between slots.
+- **Persistence:**
+  - Inventory data will be saved and loaded with the player's progress.
+  - Items will be retained between game sessions.
+
+### Future Enhancements
+- **Advanced Crafting:**
+  - More complex crafting recipes and item combinations.
+  - Integration with the world generation system for unique resources.
+- **Inventory Expansion:**
+  - Additional inventory slots and storage options.
+  - Backpacks, chests, and other storage containers.
+- **Multiplayer Support:**
+  - Shared inventory and trading between players.
+  - Cooperative crafting and resource management.

--- a/js/components/chunk-component.js
+++ b/js/components/chunk-component.js
@@ -1,4 +1,5 @@
 import TextureManager from '../utils/texture-manager.js';
+import TextureGenerator from '../utils/texture-generator.js';
 import { BlockTypes } from '../blocks/block-types.js';
 
 AFRAME.registerComponent('chunk', {
@@ -14,6 +15,7 @@ AFRAME.registerComponent('chunk', {
 
         if (loggingEnabled) console.log('Initializing chunk component:', this.data);
         this.textureManager = new TextureManager();
+        this.textureGenerator = new TextureGenerator();
         this.blocks = new Map();
         this.blockMeshes = new Map();
         this.generateChunk();
@@ -52,6 +54,9 @@ AFRAME.registerComponent('chunk', {
         if (loggingEnabled) console.log(`Created ${blocksCreated} blocks in chunk`);
         this.el.setObject3D('mesh', this.chunkGroup);
         this.el.classList.add('interactive');
+
+        // Add a plane to the chunk
+        this.addPlaneToChunk();
     },
 
     createBlock(x, y, z, blockType) {
@@ -98,5 +103,34 @@ AFRAME.registerComponent('chunk', {
         };
 
         return hslToHex(hue, saturation, lightness);
+    },
+
+    addPlaneToChunk: function() {
+        // Log the start of the plane addition process
+        if (loggingEnabled) console.log('Adding plane to chunk');
+
+        const geometry = new THREE.PlaneGeometry(this.data.size, this.data.size);
+        let material;
+
+        // Generate texture or random color for the plane
+        const textureType = 'grass'; // Example texture type
+        const textureData = this.textureGenerator.generateTexture(textureType);
+
+        if (textureData) {
+            const texture = new THREE.TextureLoader().load(textureData);
+            material = new THREE.MeshStandardMaterial({ map: texture });
+        } else {
+            const color = this.getRandomColor();
+            material = new THREE.MeshStandardMaterial({ color: color });
+        }
+
+        const plane = new THREE.Mesh(geometry, material);
+        plane.rotation.x = -Math.PI / 2; // Rotate plane to be horizontal
+        plane.position.set(this.data.size / 2, 0, this.data.size / 2);
+
+        this.chunkGroup.add(plane);
+
+        // Log the completion of the plane addition process
+        if (loggingEnabled) console.log('Plane added to chunk');
     }
 });


### PR DESCRIPTION
Add a plane to each chunk with random color or generated texture and extensive logging.

* **Chunk Component (`js/components/chunk-component.js`):**
  - Import `TextureGenerator`.
  - Initialize `TextureGenerator` in the `init` method.
  - Add a plane to each chunk in the `generateChunk` method.
  - Use `TextureGenerator` to generate texture for the plane.
  - Add random color to the plane if no texture is generated.
  - Add extensive logging for plane creation in the `generateChunk` method.

* **Documentation (`README.md`):**
  - Update hierarchy with world > parsec or large chunk 10x10x10 > chunk 10x10x10 > block 10x10x10 > voxels.
  - Add inventory ideas to documentation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JustGibas/Q-DimensionalField/pull/26?shareId=e0daf6b4-01c1-4387-a284-95608bcc6344).