### PR TITLE
Add debug info to display player position and chunk details

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
   <div id="debug-ui">
     <div>Chunks loaded: <span id="chunk-count">0</span></div>
     <div>Last chunk position: <span id="last-chunk-pos">None</span></div>
+    <div>Player position: <span id="player-position">0, 0, 0</span></div>
+    <div>Chunk count: <span id="chunk-count">0</span></div>
+    <div>Last chunk name: <span id="last-chunk-name">None</span></div>
+    <div>Last chunk position: <span id="last-chunk-pos">None</span></div>
   </div>
   <header>
     <h1>Welcome to Q-DimensionalField</h1>

--- a/src/components/player-controls.js
+++ b/src/components/player-controls.js
@@ -53,6 +53,12 @@ AFRAME.registerComponent('player-controls', {
         if (playerRig) {
             const playerPosition = playerRig.getAttribute('position');
             chunkManager.updateChunksAroundPlayer(playerPosition);
+
+            // Update the debug box with the player's current coordinate position
+            const playerPositionElement = document.getElementById('player-position');
+            if (playerPositionElement) {
+                playerPositionElement.textContent = `${playerPosition.x.toFixed(2)}, ${playerPosition.y.toFixed(2)}, ${playerPosition.z.toFixed(2)}`;
+            }
         }
     }
 });

--- a/src/world/chunk-manager.js
+++ b/src/world/chunk-manager.js
@@ -148,6 +148,25 @@ class ChunkManager {
             position: chunk.getAttribute('position'),
             containerChildren: this.container.children.length
         });
+
+        // Update the debug box with the number of chunks spawned
+        const chunkCountElement = document.getElementById('chunk-count');
+        if (chunkCountElement) {
+            chunkCountElement.textContent = this.chunks.size;
+        }
+
+        // Update the debug box with the last chunk name
+        const lastChunkNameElement = document.getElementById('last-chunk-name');
+        if (lastChunkNameElement) {
+            lastChunkNameElement.textContent = key;
+        }
+
+        // Update the debug box with the position of the spawned chunk
+        const lastChunkPosElement = document.getElementById('last-chunk-pos');
+        if (lastChunkPosElement) {
+            lastChunkPosElement.textContent = `${position.x}, ${position.y}, ${position.z}`;
+        }
+
         return chunk;
     }
 


### PR DESCRIPTION
Add values to the debug box to show the current coordinate position of the player, the number of chunks spawned, the last chunk name, and the position of the spawned chunk.

* **index.html**
  - Add a new div with id `player-position` to display the player's current coordinate position.
  - Add a new div with id `chunk-count` to display the number of chunks spawned.
  - Add a new div with id `last-chunk-name` to display the last chunk name.
  - Add a new div with id `last-chunk-pos` to display the position of the spawned chunk.

* **src/components/player-controls.js**
  - Update the `updateChunksAroundPlayer` function to update the player's current coordinate position in the debug box.

* **src/world/chunk-manager.js**
  - Update the `createChunk` function to update the number of chunks spawned in the debug box.
  - Update the `createChunk` function to update the last chunk name in the debug box.
  - Update the `createChunk` function to update the position of the spawned chunk in the debug box.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JustGibas/Q-DimensionalField/pull/37?shareId=3fc003e9-131d-43e2-a25c-88c800419062).